### PR TITLE
Redis queues names removed from initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.DS_Store
+.ruby-version

--- a/lib/redis-queue.rb
+++ b/lib/redis-queue.rb
@@ -1,2 +1,4 @@
-require "redis"
-require "redis/queue"
+require 'securerandom'
+require 'redis'
+require 'redis/queue'
+require 'redis/queue/version'

--- a/lib/redis-queue.rb
+++ b/lib/redis-queue.rb
@@ -1,3 +1,2 @@
 require "redis"
-require "redis/connection/hiredis"
 require "redis/queue"

--- a/lib/redis-queue/version.rb
+++ b/lib/redis-queue/version.rb
@@ -1,5 +1,0 @@
-class Redis
-  class Queue
-    VERSION = "0.0.4.1"
-  end
-end

--- a/lib/redis-queue/version.rb
+++ b/lib/redis-queue/version.rb
@@ -1,5 +1,5 @@
 class Redis
   class Queue
-    VERSION = "0.0.4"
+    VERSION = "0.0.4.1"
   end
 end

--- a/lib/redis-queue/version.rb
+++ b/lib/redis-queue/version.rb
@@ -1,0 +1,5 @@
+class Redis
+  class Queue
+    VERSION = "0.0.4"
+  end
+end

--- a/lib/redis/queue.rb
+++ b/lib/redis/queue.rb
@@ -1,8 +1,6 @@
 class Redis
   class Queue
 
-    VERSION = "0.0.4"
-
     def self.version
       "redis-queue version #{VERSION}"
     end

--- a/lib/redis/queue.rb
+++ b/lib/redis/queue.rb
@@ -1,29 +1,23 @@
 class Redis
+  # :nodoc:
   class Queue
-
     def self.version
       "redis-queue version #{VERSION}"
     end
 
-    def initialize(queue_name, process_queue_name, options = {})
-      raise ArgumentError, 'First argument must be a non empty string'  if !queue_name.is_a?(String) || queue_name.empty?
-      raise ArgumentError, 'Second argument must be a non empty string' if !process_queue_name.is_a?(String) || process_queue_name.empty?
-      raise ArgumentError, 'Queue and Process queue have the same name'  if process_queue_name == queue_name
-
-      @redis = options[:redis] || Redis.current
-      @queue_name = queue_name
-      @process_queue_name = process_queue_name
+    def initialize(redis: Redis.current, timeout: 0)
+      @redis = redis
+      @timeout = timeout
       @last_message = nil
-      @timeout = options[:timeout] ||= 0
     end
 
     def length
-      @redis.llen @queue_name
+      redis.llen waiting
     end
 
     def clear(clear_process_queue = false)
-      @redis.del @queue_name
-      @redis.del @process_queue_name if clear_process_queue
+      redis.del waiting
+      redis.del processing if clear_process_queue
     end
 
     def empty?
@@ -31,20 +25,15 @@ class Redis
     end
 
     def push(obj)
-      @redis.lpush(@queue_name, obj)
+      redis.lpush(waiting, obj)
     end
 
     def pop(non_block=false)
-      if non_block
-        @last_message = @redis.rpoplpush(@queue_name,@process_queue_name)
-      else
-        @last_message = @redis.brpoplpush(@queue_name,@process_queue_name, @timeout)
-      end
-      @last_message
+      @last_message = non_block ? redis.rpoplpush(waiting, processing) : redis.brpoplpush(waiting, processing, timeout)
     end
 
     def commit
-      @redis.lrem(@process_queue_name, 0, @last_message)
+      redis.lrem(processing, 0, @last_message)
     end
 
     def process(non_block=false, timeout=nil, count=nil)
@@ -61,10 +50,18 @@ class Redis
     end
 
     def refill
-      while message=@redis.lpop(@process_queue_name)
-        @redis.rpush(@queue_name, message)
+      while message = redis.lpop(processing)
+        redis.rpush(waiting, message)
       end
       true
+    end
+
+    def waiting
+      @waiting ||= SecureRandom.uuid
+    end
+
+    def processing
+      @processing ||= SecureRandom.uuid
     end
 
     alias :size  :length
@@ -72,5 +69,8 @@ class Redis
     alias :shift :pop
     alias :enc   :push
     alias :<<    :push
+
+    private
+      attr_accessor :redis, :timeout
   end
 end

--- a/lib/redis/queue/version.rb
+++ b/lib/redis/queue/version.rb
@@ -1,0 +1,7 @@
+# :nodoc:
+class Redis
+  # :nodoc:
+  class Queue
+    VERSION = '0.0.5'
+  end
+end

--- a/redis-queue.gemspec
+++ b/redis-queue.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'redis', '~> 3.0', '>= 3.0.4'
-  s.add_runtime_dependency 'hiredis', '~> 0.5', '>= 0.5.2'
+  s.add_runtime_dependency 'redis', '~> 3.2'
 
   s.add_development_dependency 'rspec', '~> 2.13', '>= 2.13.0'
 end

--- a/redis-queue.gemspec
+++ b/redis-queue.gemspec
@@ -1,6 +1,7 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "redis-queue/version"
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'redis/queue/version'
 
 Gem::Specification.new do |s|
   s.name        = "redis-queue"

--- a/redis-queue.gemspec
+++ b/redis-queue.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "redis-queue"
+require "redis-queue/version"
 
 Gem::Specification.new do |s|
   s.name        = "redis-queue"

--- a/spec/redis_queue_spec.rb
+++ b/spec/redis_queue_spec.rb
@@ -96,7 +96,7 @@ describe Redis::Queue do
       is_ok = false
     end
     
-    is_ok.should be_true
+    is_ok.should be true
 
   end
 
@@ -114,7 +114,7 @@ describe Redis::Queue do
       is_ok = false
     end
     queue.clear
-    is_ok.should be_true
+    is_ok.should be true
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,10 @@ require 'rubygems'
 require 'bundler'
 require 'rspec'
 
-
 RSpec.configure do |config|
   config.color = true
 end
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+
 require 'redis-queue'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'rspec'
 
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
 end
 
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')


### PR DESCRIPTION
I have slightly refactored the code: merged the changes I found other people have forked, bumped the version to 0.5, and mainly, removed the names of Redis queues as a requirement for instance initialization
