### PR TITLE
Relax dependencies, fix gemspec outdated error

### DIFF
--- a/redis-queue.gemspec
+++ b/redis-queue.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "redis-queue"
+require File.expand_path('../lib/redis/queue', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "redis-queue"
@@ -24,8 +23,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'redis', '~> 3.0', '>= 3.0.4'
-  s.add_runtime_dependency 'hiredis', '~> 0.5', '>= 0.5.2'
+  s.add_runtime_dependency 'redis', '>= 3.3.5', '< 5'
+  s.add_runtime_dependency 'hiredis', '~> 0.6'
 
   s.add_development_dependency 'rspec', '~> 2.13', '>= 2.13.0'
 end


### PR DESCRIPTION
This gemspec was forcing down my redis version and I need to stay up to date.

Followed the hiredis and sidekiq versioning recommendations.