### PR TITLE
Deprecate Redis.current

### DIFF
--- a/lib/redis/queue.rb
+++ b/lib/redis/queue.rb
@@ -12,8 +12,9 @@ class Redis
       raise ArgumentError, 'First argument must be a non empty string'  if !queue_name.is_a?(String) || queue_name.empty?
       raise ArgumentError, 'Second argument must be a non empty string' if !process_queue_name.is_a?(String) || process_queue_name.empty?
       raise ArgumentError, 'Queue and Process queue have the same name' if process_queue_name == queue_name
+      raise ArgumentError, 'Redis is required' if options[:redis].nil?
 
-      @redis = options[:redis] || Redis.current
+      @redis = options[:redis]
       @queue_name = queue_name
       @process_queue_name = process_queue_name
       @last_message = nil

--- a/spec/redis_queue_spec.rb
+++ b/spec/redis_queue_spec.rb
@@ -19,7 +19,7 @@ describe Redis::Queue do
   end
 
   it 'should create a new redis-queue object' do
-    queue = Redis::Queue.new('__test', 'bp__test')
+    queue = Redis::Queue.new('__test', 'bp__test', redis: @redis)
     queue.class.should == Redis::Queue
   end
 


### PR DESCRIPTION
#### What problem does this address?
[Version 5 of the Ruby Redis gem removes Redis.current
](https://makandracards.com/makandra/510011-version-5-of-the-ruby-redis-gem-removes-redis-current)

![image](https://user-images.githubusercontent.com/69775411/186853955-47935142-e7aa-4d71-a7c3-78acc601c8be.png)