### PR TITLE
Bump Redis to 5.0

### DIFF
--- a/lib/redis/queue.rb
+++ b/lib/redis/queue.rb
@@ -2,7 +2,7 @@
 
 class Redis
   class Queue
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
 
     def self.version
       "redis-queue version #{VERSION}"

--- a/redis-queue.gemspec
+++ b/redis-queue.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'redis', '>= 3.3.5', '< 5'
+  s.add_runtime_dependency 'redis', '>= 3.3.5', '<= 5'
 
   s.add_development_dependency 'rspec', '~> 2.13', '>= 2.13.0'
 end

--- a/spec/redis_queue_spec.rb
+++ b/spec/redis_queue_spec.rb
@@ -6,7 +6,7 @@ require 'timeout'
 describe Redis::Queue do
   before(:all) do
     @redis = Redis.new
-    @queue = Redis::Queue.new('__test', 'bp__test')
+    @queue = Redis::Queue.new('__test', 'bp__test', redis: @redis)
     @queue.clear true
   end
 


### PR DESCRIPTION
remove deprecation message Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead. from the redis gem

https://github.com/redis/redis-rb/pull/1134